### PR TITLE
fix duplicated tasks in the ispmail-postfix role

### DIFF
--- a/ansible/roles/ispmail-postfix/tasks/main.yml
+++ b/ansible/roles/ispmail-postfix/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: define Postfix virtual mailbox domain mapping
+- name: define Postfix virtual mappings
   template: 
     src: "{{item}}.j2"
     dest: "/etc/postfix/{{item}}"
@@ -21,30 +21,14 @@
 - name: tell Postfix to use the virtual mailbox domain mapping
   command: postconf virtual_mailbox_domains=mysql:/etc/postfix/mysql-virtual-mailbox-domains.cf
 
-- name: define Postfix virtual mailbox mapping
-  template: src=mysql-virtual-mailbox-maps.cf.j2 dest=/etc/postfix/mysql-virtual-mailbox-maps.cf
-  notify: restart postfix
 - name: tell Postfix to use the virtual mailbox mapping
   command: postconf virtual_mailbox_maps=mysql:/etc/postfix/mysql-virtual-mailbox-maps.cf
 
-- name: define Postfix virtual alias mapping
-  template: src=mysql-virtual-alias-maps.cf.j2 dest=/etc/postfix/mysql-virtual-alias-maps.cf
-  notify: restart postfix
 - name: tell Postfix to use the virtual alias mapping
   command: postconf virtual_alias_maps=mysql:/etc/postfix/mysql-virtual-alias-maps.cf
 
-- name: define Postfix email-to-email mapping (required for catchall domains)
-  template: src=mysql-email2email.cf.j2 dest=/etc/postfix/mysql-email2email.cf
-  notify: restart postfix
 - name: tell Postfix to use the email-to-email mapping
   command: postconf virtual_alias_maps=mysql:/etc/postfix/mysql-virtual-alias-maps.cf,mysql:/etc/postfix/mysql-email2email.cf
-
-- name: Restricting access to database mapping files that contain a password
-  file: path=/etc/postfix/mysql-{{item}}.cf mode=0640
-  with_items:
-  - virtual-mailbox-domains
-  - virtual-mailbox-maps
-  - virtual-alias-maps
 
 - name: Make Postfix use LMTP to send emails to Dovecot
   command: postconf virtual_transport=lmtp:unix:private/dovecot-lmtp
@@ -86,16 +70,7 @@
   command: postconf non_smtpd_milters=inet:127.0.0.1:11332
 
 - name: Set rspamd milter macros
-  command: postconf milter_mail_macros="i {mail_addr} {client_addr} {client_name} {auth_authen}'"
+  command: "postconf milter_mail_macros='i {mail_addr} {client_addr} {client_name} {auth_authen}'"
 
 - name: Enable user quota checking
   command: "postconf 'smtpd_recipient_restrictions = reject_unauth_destination check_policy_service unix:private/quota-status'"
-
-- name: Enable rspamd milter for smtpd
-  command: "postconf smtpd_milters=inet:127.0.0.1:11332"
-
-- name: Enable rspamd milter for local mails
-  command: "postconf non_smtpd_milters=inet:127.0.0.1:11332"
-
-- name: Configure rspamd milter macros
-  command: "postconf milter_mail_macros='i {mail_addr} {client_addr} {client_name} {auth_authen}'"

--- a/ansible/roles/ispmail-postfix/tasks/main.yml
+++ b/ansible/roles/ispmail-postfix/tasks/main.yml
@@ -24,9 +24,6 @@
 - name: tell Postfix to use the virtual mailbox mapping
   command: postconf virtual_mailbox_maps=mysql:/etc/postfix/mysql-virtual-mailbox-maps.cf
 
-- name: tell Postfix to use the virtual alias mapping
-  command: postconf virtual_alias_maps=mysql:/etc/postfix/mysql-virtual-alias-maps.cf
-
 - name: tell Postfix to use the email-to-email mapping
   command: postconf virtual_alias_maps=mysql:/etc/postfix/mysql-virtual-alias-maps.cf,mysql:/etc/postfix/mysql-email2email.cf
 
@@ -41,9 +38,6 @@
 
 - name: Enabling SMTP authentication
   command: postconf smtpd_sasl_auth_enable=yes
-
-- name: Setting SMTP encryption security level
-  command: postconf smtpd_tls_security_level=may
 
 - name: Setting SMTP encryption security level
   command: postconf smtpd_tls_security_level=may


### PR DESCRIPTION
The `ispmail-postfix` role contains duplicated tasks which seem to originate from different versions of the playbook.

I suspect that merging some changes in the past did something funky.

This PR attempts to clean it up :

- It seems that you decided to regroup the use of templates in the first task. Therefore there is no need to re-use these templates for virtual mailbox, virtual alias and email-to-email later on. I removed the corresponding tasks.
- Restricting the access to the mappings containing passwords is also done when using the templates via the `mode: 0640` argument. I removed the corresponding task.
- The postconf commands for rspamd are executed twice. I removed the superfluous ones. And fixed a quote mismatch in one of them.

Thank you for your awesome guide ! :slightly_smiling_face: 